### PR TITLE
Add SNR tracking to ClickHouse pipeline; refactor dbZoneFiller

### DIFF
--- a/PythonFiles/dbZoneFiller.py
+++ b/PythonFiles/dbZoneFiller.py
@@ -2,74 +2,240 @@ import mysql.connector
 from mysql.connector import Error
 import ctypes
 import os
+import time
+from datetime import timedelta
 
-dir = os.path.dirname(__file__)
+BATCH_SIZE = 5000   # rows per read chunk and per write commit
 
-# load dll
-chart_gen = ctypes.WinDLL(f'{dir}/Ft8ChartGen.dll')
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+chart_gen = ctypes.WinDLL(f'{dir_path}/Ft8ChartGen.dll')
 chart_gen.SquareToItuZone.argtypes = [ctypes.c_wchar_p]
-commit_part_count = 1000
+chart_gen.SquareToItuZone.restype = ctypes.c_int
 
-try:
-    connection = mysql.connector.connect(host='localhost', database='main', user='root', password='1q2w3e$R')
-    if connection.is_connected():
-        db_Info = connection.get_server_info()
-        print("Connected to MySQL Server version ", db_Info)
-        cursor = connection.cursor()
-        cursor.execute("select database();")
-        record = cursor.fetchone()
-        print("You're connected to database: ", record)
 
-        sql_select_Query = "select id, callsign, grid from main.ft8_stationinfo where ituZone = 0 and grid != ''"
-        cursor = connection.cursor(prepared=True)
-        cursor.execute(sql_select_Query)
-        # get all records
-        records = cursor.fetchall()
-        row_cnt = cursor.rowcount
+# ---------------------------------------------------------------------------
+# Progress / statistics
+# ---------------------------------------------------------------------------
 
-        print("Total number of rows in table: ", row_cnt)
-        countToCommit = 0
-        if row_cnt > 0:
-            updates = []
+class Stats:
+    def __init__(self, total: int):
+        self.total = total
+        self.processed = 0
+        self.success = 0
+        self.failed = 0
+        self.fallback_used = 0
+        self._start = time.monotonic()
+        self._last_print = 0.0
 
-            for row in records:
-                id = row[0]
-                square = row[2]
+    def record(self, zone: int, used_fallback: bool = False):
+        self.processed += 1
+        if zone > 0:
+            self.success += 1
+            if used_fallback:
+                self.fallback_used += 1
+        else:
+            self.failed += 1
 
-                zone = chart_gen.SquareToItuZone(square)
-                if (zone == 0):
-                    zone = -1
-                    print("Incorrect entry: id=", id, " callsign=", row[1], " square=", square)
-                    #TODO: additional check, for first 4 chars of grid (if it already not 4 chars len).
+    @property
+    def elapsed(self) -> float:
+        return time.monotonic() - self._start
+
+    @property
+    def rate(self) -> float:
+        return self.processed / self.elapsed if self.elapsed > 0 else 0.0
+
+    @property
+    def eta_sec(self) -> float:
+        remaining = self.total - self.processed
+        return remaining / self.rate if self.rate > 0 else 0.0
+
+    def print_progress(self, force: bool = False):
+        now = time.monotonic()
+        if not force and (now - self._last_print) < 0.5:
+            return
+        self._last_print = now
+
+        if self.total == 0:
+            return
+        pct = self.processed / self.total
+        bar_w = 35
+        filled = int(bar_w * pct)
+        bar = '█' * filled + '░' * (bar_w - filled)
+        eta = str(timedelta(seconds=int(self.eta_sec)))
+        print(
+            f"\r[{bar}] {pct*100:5.1f}%  "
+            f"{self.processed:,}/{self.total:,}  "
+            f"{self.rate:,.0f} rec/s  "
+            f"ETA {eta}  "
+            f"OK:{self.success:,} Fail:{self.failed:,}",
+            end='', flush=True
+        )
+
+    def print_summary(self):
+        elapsed = str(timedelta(seconds=int(self.elapsed)))
+        pct_ok   = self.success  / self.total * 100 if self.total else 0
+        pct_fail = self.failed   / self.total * 100 if self.total else 0
+        print(f"\n\n{'='*60}")
+        print(f"  Completed in       {elapsed}")
+        print(f"  Total processed:   {self.total:,}")
+        print(f"  Success:           {self.success:,}  ({pct_ok:.1f}%)")
+        if self.fallback_used:
+            print(f"    incl. 4-char fallback: {self.fallback_used:,}")
+        print(f"  Failed (→ -1):     {self.failed:,}  ({pct_fail:.1f}%)")
+        print(f"  Avg throughput:    {self.rate:,.0f} records/sec")
+        print(f"{'='*60}")
+
+
+# ---------------------------------------------------------------------------
+# Zone resolution
+# ---------------------------------------------------------------------------
+
+def resolve_zone(grid: str) -> tuple[int, bool]:
+    """
+    Resolve a Maidenhead grid square to an ITU zone number.
+
+    Tries the full grid first, then falls back to the 4-character prefix
+    (some older locators stored in the DB are already 4-char, others may
+    have a corrupt 5th/6th character).
+
+    Returns:
+        (zone, used_fallback)
+        zone > 0  — valid ITU zone
+        zone == -1 — could not resolve; mark as invalid in DB
+    """
+    zone = chart_gen.SquareToItuZone(grid)
+    if zone > 0:
+        return zone, False
+
+    if len(grid) > 4:
+        zone = chart_gen.SquareToItuZone(grid[:4])
+        if zone > 0:
+            return zone, True
+
+    return -1, False
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def get_pending_count(connection) -> int:
+    cursor = connection.cursor()
+    cursor.execute(
+        "SELECT COUNT(*) FROM main.ft8_stationinfo WHERE ituZone = 0 AND grid != ''"
+    )
+    count = cursor.fetchone()[0]
+    cursor.close()
+    return count
+
+
+def ensure_temp_table(write_cursor):
+    write_cursor.execute("""
+        CREATE TEMPORARY TABLE IF NOT EXISTS _zone_updates (
+            id      INT PRIMARY KEY,
+            ituZone INT NOT NULL
+        )
+    """)
+
+
+def flush_batch(write_cursor, write_conn, updates: list, failures: list):
+    """
+    Persist one batch of resolved zones to the database and commit.
+
+    updates  — list of (id, zone) for successfully resolved stations
+    failures — list of station ids that could not be resolved (zone → -1)
+    """
+    if not updates and not failures:
+        return
+
+    if updates:
+        write_cursor.execute("DELETE FROM _zone_updates")
+        write_cursor.executemany(
+            "INSERT INTO _zone_updates (id, ituZone) VALUES (%s, %s)",
+            updates
+        )
+        write_cursor.execute("""
+            UPDATE main.ft8_stationinfo AS s
+            JOIN _zone_updates AS u ON s.id = u.id
+            SET s.ituZone = u.ituZone
+        """)
+
+    if failures:
+        # Mark as -1 so they are skipped on future runs
+        write_cursor.executemany(
+            "UPDATE main.ft8_stationinfo SET ituZone = -1 WHERE id = %s",
+            [(fid,) for fid in failures]
+        )
+
+    write_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    read_conn  = None
+    write_conn = None
+    try:
+        db_cfg = dict(host='localhost', database='main', user='root', password='1q2w3e$R')
+
+        read_conn  = mysql.connector.connect(**db_cfg)
+        write_conn = mysql.connector.connect(**db_cfg)
+        print(f"Connected to MySQL {read_conn.get_server_info()}")
+
+        total = get_pending_count(read_conn)
+        if total == 0:
+            print("Nothing to do — all stations already have ITU zones assigned.")
+            return
+
+        print(f"Pending stations: {total:,}  (batch size: {BATCH_SIZE:,})\n")
+        stats = Stats(total)
+
+        # Unbuffered cursor streams rows from server without loading all into RAM
+        read_cursor = read_conn.cursor(buffered=False)
+        read_cursor.execute(
+            "SELECT id, callsign, grid FROM main.ft8_stationinfo WHERE ituZone = 0 AND grid != ''"
+        )
+
+        write_cursor = write_conn.cursor()
+        ensure_temp_table(write_cursor)
+
+        updates:  list[tuple[int, int]] = []
+        failures: list[int]             = []
+
+        while True:
+            rows = read_cursor.fetchmany(BATCH_SIZE)
+            if not rows:
+                break
+
+            for station_id, callsign, grid in rows:
+                zone, used_fallback = resolve_zone(grid)
+                stats.record(zone, used_fallback)
+
+                if zone > 0:
+                    updates.append((station_id, zone))
                 else:
-                    tuple1 = (id, zone)
-                    updates.append(tuple1)
+                    failures.append(station_id)
 
-            cursor.execute("""
-            CREATE TEMPORARY TABLE temp_updates (
-                id INT PRIMARY KEY,
-                ituZone INT
-            );
-            """)
+            flush_batch(write_cursor, write_conn, updates, failures)
+            updates.clear()
+            failures.clear()
+            stats.print_progress(force=True)
 
-            insert_query = "INSERT INTO temp_updates (id, ituZone) VALUES (%s, %s)"
-            cursor.executemany(insert_query, updates)
+        stats.print_summary()
 
-            update_query = """
-            UPDATE main.ft8_stationinfo AS main
-            JOIN temp_updates AS temp
-            ON main.id = temp.id
-            SET main.ituZone = temp.ituZone;
-            """
-            cursor.execute(update_query)
-            connection.commit()
+    except Error as e:
+        print(f"\nMySQL error: {e}")
+    except KeyboardInterrupt:
+        print("\n\nInterrupted by user. Progress up to last commit is saved.")
+    finally:
+        for conn in (read_conn, write_conn):
+            if conn and conn.is_connected():
+                conn.close()
+        print("Connections closed.")
 
-except Error as e:
-    print("Error while connecting to MySQL", e)
 
-finally:
-    if connection:
-        if connection.is_connected():
-            cursor.close()
-            connection.close()
-            print("MySQL connection is closed")
+if __name__ == '__main__':
+    main()

--- a/PythonFiles/flyImportReportTable.py
+++ b/PythonFiles/flyImportReportTable.py
@@ -42,7 +42,7 @@ def decompressAndAlterReportFile(reportSuffix, dicZones):
     # out_file_header = "spotId,utc,band,zone1,zone2\n"
     # out_file_header = "utc,band,zone1,zone2,dxcc1,dxcc2\n"
     # out_file_header = "utc,band,zone1,zone2,cnt\n"
-    out_file_header = "utc,band,zone1,zone2,grid1,grid2,lat1,lon1,lat2,lon2,cnt\n"
+    out_file_header = "utc,band,zone1,zone2,grid1,grid2,lat1,lon1,lat2,lon2,cnt,snr\n"
     bunchsize = 1912000  # Experiment with different sizes
     bunch = []
 
@@ -67,8 +67,10 @@ def decompressAndAlterReportFile(reportSuffix, dicZones):
                                     lat1, lon1 = mh.to_location(grid1)
                                     lat2, lon2 = mh.to_location(grid2)
 
-                                    # spot = fields[9] + "," + fields[14][1:-1] + "," + str(zone1[0]) + "," + str(zone2[0]) + "," + str(fields[12]) + "," + str(fields[13]) + "\n"
-                                    spot = fields[9] + "," + fields[14][1:-1] + "," + str(zone1[0]) + "," + str(zone2[0]) + "," + grid1 + "," + grid2 + "," + str(lat1) + "," + str(lon1) + "," + str(lat2) + "," + str(lon2) +",1\n"
+                                    snr_raw = fields[7]
+                                    snr = int(snr_raw) if snr_raw != 'NULL' else 0
+
+                                    spot = fields[9] + "," + fields[14][1:-1] + "," + str(zone1[0]) + "," + str(zone2[0]) + "," + grid1 + "," + grid2 + "," + str(lat1) + "," + str(lon1) + "," + str(lat2) + "," + str(lon2) + ",1," + str(snr) + "\n"
                                     bunch.append(spot)
                                     spot_count += 1
 
@@ -151,6 +153,24 @@ def determineUTCminMax(reportSuffix, clickhouseClient):
     return utcMin, utcMax
 
 
+def ensure_table_snr_column(table_name, clickhouseClient):
+    """Add snr Int32 column to existing tables that predate the SNR change."""
+    columns = clickhouseClient.execute(
+        f"SELECT name FROM system.columns WHERE database='default' AND table='{table_name}'"
+    )
+    existing = {row[0] for row in columns}
+    if 'snr' not in existing:
+        clickhouseClient.execute(f'ALTER TABLE default.`{table_name}` ADD COLUMN `snr` Int32 DEFAULT 0')
+        print(f"Added snr column to {table_name}")
+    if 'cnt' in existing:
+        col_type = clickhouseClient.execute(
+            f"SELECT type FROM system.columns WHERE database='default' AND table='{table_name}' AND name='cnt'"
+        )
+        if col_type and col_type[0][0] == 'UInt8':
+            clickhouseClient.execute(f'ALTER TABLE default.`{table_name}` MODIFY COLUMN `cnt` UInt32')
+            print(f"Upgraded cnt UInt8→UInt32 in {table_name}")
+
+
 @benchmark
 def process_report_dump_file(reportSuffix, clickhouseClient):
     if clickhouseClient:
@@ -175,14 +195,15 @@ def process_report_dump_file(reportSuffix, clickhouseClient):
             '`lat1` Float64, '
             '`lon1` Float64, '
             '`lat2` Float64, '
-            '`lon2` Float64, '            
-            '`cnt` UInt8 '
-            # '`dxcc1` Int32, '
-            # '`dxcc2` Int32 '
+            '`lon2` Float64, '
+            '`cnt` UInt32, '
+            '`snr` Int32 '
             ')ENGINE = SummingMergeTree '
             'ORDER BY (utc, band, zone1, zone2, grid1, grid2, lat1, lon1, lat2, lon2) '
             'PARTITION BY toYYYYMMDD(toDateTime(utc)) '
             'PRIMARY KEY (utc, band, zone1, zone2, grid1, grid2, lat1, lon1, lat2, lon2); ')
+
+        ensure_table_snr_column(f'spots_sum_grid_ll_{tableSuffix}', clickhouseClient)
 
         schema = {
             'utc': int,
@@ -193,8 +214,7 @@ def process_report_dump_file(reportSuffix, clickhouseClient):
             'lat2': float,
             'lon2': float,
             'cnt': int,
-            # 'dxcc1': int,
-            # 'dxcc2': int,
+            'snr': int,
         }
         bypass = lambda x: x
 

--- a/SQLFiles/clickhouse_snr_migration.sql
+++ b/SQLFiles/clickhouse_snr_migration.sql
@@ -1,0 +1,71 @@
+-- Migration: add snr column to existing spots_sum_grid_ll_* tables
+-- Run once per table that was loaded before the SNR change.
+-- Python's ensure_table_snr_column() does this automatically for new imports;
+-- use these queries for any tables already in ClickHouse.
+
+-- Step 1: add snr column (DEFAULT 0 — historical rows have no SNR data)
+ALTER TABLE default.spots_sum_grid_ll_YYYY_MM ADD COLUMN `snr` Int32 DEFAULT 0;
+
+-- Step 2: upgrade cnt from UInt8 (max 255) to UInt32
+-- Necessary because SummingMergeTree accumulates counts far beyond 255.
+ALTER TABLE default.spots_sum_grid_ll_YYYY_MM MODIFY COLUMN `cnt` UInt32;
+
+-- Verify result
+SELECT name, type
+FROM system.columns
+WHERE database = 'default' AND table = 'spots_sum_grid_ll_YYYY_MM'
+ORDER BY position;
+
+
+-- ============================================================
+-- Grafana query examples
+-- ============================================================
+
+-- 1. Zone-pair heatmap (VOACAP-style): date × UTC quarter-hour, colored by spot count
+--    Grafana panel: Heatmap  |  X = day, Y = quarter_hour, Value = spots
+SELECT
+    toStartOfDay(toDateTime(utc))                                         AS day,
+    toHour(toDateTime(utc)) * 4 + intDiv(toMinute(toDateTime(utc)), 15)  AS quarter_hour,
+    sum(cnt)                                                              AS spots
+FROM default.spots_sum_grid_ll_2023_01
+WHERE band = '20m'
+  AND ((zone1 = 8 AND zone2 = 27) OR (zone1 = 27 AND zone2 = 8))
+GROUP BY day, quarter_hour
+ORDER BY day, quarter_hour;
+
+
+-- 2. Average SNR heatmap: same structure, value = avg SNR
+--    Overlay this on the count heatmap to see signal quality
+SELECT
+    toStartOfDay(toDateTime(utc))                                         AS day,
+    toHour(toDateTime(utc)) * 4 + intDiv(toMinute(toDateTime(utc)), 15)  AS quarter_hour,
+    sum(cnt)                                                              AS spots,
+    if(sum(cnt) > 0, sum(snr) / sum(cnt), 0)                            AS avg_snr
+FROM default.spots_sum_grid_ll_2023_01
+WHERE band = '20m'
+  AND ((zone1 = 8 AND zone2 = 27) OR (zone1 = 27 AND zone2 = 8))
+GROUP BY day, quarter_hour
+ORDER BY day, quarter_hour;
+
+
+-- 3. Band comparison: activity by hour across all bands for a zone pair
+SELECT
+    band,
+    toHour(toDateTime(utc))               AS utc_hour,
+    sum(cnt)                              AS spots,
+    if(sum(cnt) > 0, sum(snr) / sum(cnt), 0) AS avg_snr
+FROM default.spots_sum_grid_ll_2023_01
+WHERE (zone1 = 8 AND zone2 = 27) OR (zone1 = 27 AND zone2 = 8)
+GROUP BY band, utc_hour
+ORDER BY band, utc_hour;
+
+
+-- 4. SNR distribution by band (histogram input)
+SELECT
+    band,
+    round(snr / cnt) AS snr_bucket,
+    sum(cnt)         AS spots
+FROM default.spots_sum_grid_ll_2023_01
+WHERE (zone1 = 8 AND zone2 = 27) OR (zone1 = 27 AND zone2 = 8)
+GROUP BY band, snr_bucket
+ORDER BY band, snr_bucket;


### PR DESCRIPTION
## Summary

- **SNR field added to ClickHouse** — `flyImportReportTable.py` now extracts `sNR` (fields[7]) from PSK Reporter SQL dumps and stores it in ClickHouse as `snr Int32`. `SummingMergeTree` accumulates the sum; average SNR at query time is `sum(snr)/sum(cnt)`. Enables signal quality analysis alongside spot count.
- **`cnt` type widened** — `UInt8` to `UInt32` to avoid silent truncation of accumulated counts above 255 on busy zone pairs.
- **Auto-migration for existing tables** — `ensure_table_snr_column()` runs on every import, adding `snr` and upgrading `cnt` type if missing. Manual SQL migration scripts in `SQLFiles/clickhouse_snr_migration.sql`.
- **`dbZoneFiller.py` fully rewritten** — streaming unbuffered read cursor plus separate write connection; batch commits every 5000 records (crash-safe); 4-char Maidenhead fallback for unresolvable 6-char grids; invalid entries written as `ituZone=-1` so future runs skip them; live progress bar with %, rate, and ETA; final statistics summary.

## Test plan

- [ ] Run `flyImportReportTable.py` on a fresh day dump; verify `snr` column populated in ClickHouse
- [ ] Confirm `ensure_table_snr_column()` adds column to a pre-existing table without data loss
- [ ] Run `dbZoneFiller.py` against a DB with pending stations; verify progress bar, batch commits, -1 written for bad grids
- [ ] Interrupt `dbZoneFiller.py` with Ctrl+C mid-run; verify already-committed batches are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)